### PR TITLE
Recursive timer decorator

### DIFF
--- a/code_timer/timer.py
+++ b/code_timer/timer.py
@@ -126,9 +126,6 @@ class Timer:
         self.__elapsed_time = None
 
         # Add new name to dictionary of timers
-        self._set_timer()
-
-    def _set_timer(self):
         self.timers.setdefault(self.__name, 0)
 
     @property
@@ -165,12 +162,6 @@ class Timer:
         # logger.debug(f"Timer stop: {end_time}")
         # logger.debug(f"Elapsed time: {self.__elapsed_time:0.6f} ms")
         return self.__elapsed_time
-
-    def clear(self, name: str = None) -> None:
-        if name is None:
-            self.timers = {}
-        else:
-            self.timers[name] = 0
 
     def update_name(self, name: str):
         self.timers[name] = self.timers.pop(self.__name)

--- a/code_timer/timer.py
+++ b/code_timer/timer.py
@@ -74,10 +74,7 @@ def timeit(f=None, *, num_repeats: int = 10000, name: str = None):
 
 
 def recursive_timer(f):
-    """
-    Timer specifically for recursion
-    By default will print out the total elapsed time in microseconds
-    """
+    """Timer specifically for recursive calls"""
     is_evaluating = False
     timer = Timer()
 

--- a/code_timer/timer.py
+++ b/code_timer/timer.py
@@ -73,8 +73,46 @@ def timeit(f=None, *, num_repeats: int = 10000, name: str = None):
     return wrapped_f
 
 
+def recursive_timer(f):
+    """
+    Timer specifically for recursion
+    By default will print out the total elapsed time in microseconds
+    """
+    is_evaluating = False
+    timer = Timer()
+
+    # support passing keyword to @recursive_timer(stdout=False) or @recursive_timer()
+    if f is None:
+        return functools.partial(recursive_timer)
+
+    @functools.wraps(f)
+    def wrapped_func(*args, **kwargs):
+        nonlocal is_evaluating, timer
+
+        if is_evaluating:
+            return f(*args, **kwargs)
+
+        timer.start()
+        is_evaluating = True
+        try:
+            value = f(*args, **kwargs)
+        finally:
+            timer.update_name(f"{f.__name__}{args, kwargs}")
+            is_evaluating = False
+        timer.stop()
+        logger.debug(timer)
+        logger.info(
+            f"Elapsed time '{f.__name__}{args, kwargs}': "
+            f"{timer.elapsed_time:0.6f} ms"
+        )
+        return value
+
+    return wrapped_func
+
+
 class Timer:
     timers = dict()
+    DEFAULT_TIMER = "default"
 
     def __init__(self, name: str = None):
         """
@@ -83,21 +121,15 @@ class Timer:
             result with one total time.  The timer name is the dictionary
             key and the accumulated time is the dictionary value.
         """
-        self.__name = name
+        self.__name = name or self.DEFAULT_TIMER
         self.__start_time = None
         self.__elapsed_time = None
 
         # Add new name to dictionary of timers
-        self.timers.setdefault(name, 0)
+        self._set_timer()
 
-    @property
-    def get_timer(self) -> dict:
-        """
-        Get timer name and associated time value
-
-        :return: dictionary of the timer name and run time for that timer name
-        """
-        return self.timers
+    def _set_timer(self):
+        self.timers.setdefault(self.__name, 0)
 
     @property
     def elapsed_time(self):
@@ -108,7 +140,7 @@ class Timer:
         if self.__start_time is not None:
             raise TimerError("Timer is running. Use .stop() to stop it")
         self.__start_time = time.perf_counter()
-        logger.debug(f"Timer start: {self.__start_time}")
+        # logger.debug(f"Timer start: {self.__start_time}")
 
     def stop(self) -> float:
         """
@@ -124,12 +156,25 @@ class Timer:
 
         if self.__name:
             # Accumulating time for timers with the same name
-            self.timers[self.__name] += self.__elapsed_time
-            logger.info(f"Using custom timer: {self.__repr__()}")
+            try:
+                self.timers[self.__name] += self.__elapsed_time
+            except KeyError:
+                self.timers[self.__name] = 0
+        logger.debug(repr(self))
 
-        logger.debug(f"Timer stop: {end_time}")
-        logger.debug(f"Elapsed time: {self.__elapsed_time:0.6f} ms")
+        # logger.debug(f"Timer stop: {end_time}")
+        # logger.debug(f"Elapsed time: {self.__elapsed_time:0.6f} ms")
         return self.__elapsed_time
+
+    def clear(self, name: str = None) -> None:
+        if name is None:
+            self.timers = {}
+        else:
+            self.timers[name] = 0
+
+    def update_name(self, name: str):
+        self.timers[name] = self.timers.pop(self.__name)
+        self.__name = name
 
     def __call__(self, func):
         """Support using Timer as a decorator"""
@@ -159,6 +204,7 @@ class Timer:
     def __repr__(self) -> str:
         return (
             f"{Timer.__name__} "
-            f"(name='{self.__name}'; "
-            f"acc_time={self.get_timer[self.__name]:0.6f} ms)"
+            f"(name='{self.__name}', "
+            f"elapsed={self.__elapsed_time:0.6f} ms, "
+            f"acc_time={self.timers.get(self.__name):0.6f} ms)"
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
-# Inside of setup.cfg
 [flake8]
-max_line_length = 79
+max_line_length = 88
 description-file = README.md

--- a/tests/test_code_timer.py
+++ b/tests/test_code_timer.py
@@ -21,41 +21,7 @@ TIMEIT_LOG = f"best 3 of {DEFAULT_TIMEIT_REPEATS} for "
 
 def timer_func(loop: int = DEFAULT_LOOPS):
     sum(n ** 2 for n in range(loop))
-
-
-@ct.timer
-def decorated_timer_no_brackets():
-    timer_func()
-
-
-@ct.timer()
-def decorated_timer_with_brackets():
-    timer_func()
-
-
-@ct.timer(name=TIMER_NAME)
-def decorated_timer_name_passed():
-    timer_func()
-
-
-@ct.timeit(num_repeats=DEFAULT_TIMEIT_REPEATS)
-def decorated_timeit_num_repeats():
-    timer_func()
-
-
-@ct.timeit(num_repeats=DEFAULT_TIMEIT_REPEATS, name=TIMER_NAME)
-def decorated_timeit_num_repeats_and_name():
-    timer_func()
-
-
-@ct.timeit()
-def decorated_timeit_with_brackets_no_arguments():
-    timer_func()
-
-
-@ct.timeit
-def decorated_timeit_no_brackets():
-    timer_func()
+    return 3
 
 
 @pytest.fixture(autouse=True)
@@ -78,13 +44,15 @@ def propogate_package_logger():
 
 
 class TestTimerClass:
-    def test_timer_class_as_context_manager(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=PACKAGE_LOGGER)
-        with ct.Timer():
+    def test_timer_init(self):
+        t = ct.Timer(name="my_name")
+        assert t.elapsed_time is None
+        assert "my_name" in t.timers
+
+    def test_timer_class_as_context_manager(self):
+        with ct.Timer() as t:
             timer_func()
-        log = caplog.records[-1].getMessage().lower()
-        assert RE_ELAPSED_TIME.match(log), \
-            f"Did not find text {str(RE_ELAPSED_TIME)} in log: {log}"
+        assert t.elapsed_time is not None and t.elapsed_time >= 0
 
     def test_timer_error_if_stop_timer_when_not_running(self):
         t = ct.Timer()
@@ -100,16 +68,13 @@ class TestTimerClass:
     def test_get_timer_info_when_name_not_passed(self):
         with ct.Timer() as t:
             timer_func()
-        print(t.get_timer)
-        assert isinstance(t.get_timer, dict), "get_timer did not return a " \
-                                              "dictionary instance"
-        assert t.get_timer == {None: 0}, \
-            "get_timer did not return {None: 0} when a timer name was " \
+        assert isinstance(t.timers, dict), (
+            "get_timer did not return a " "dictionary instance"
+        )
+        assert "default" in t.timers.keys(), (
+            "get_timer did not return {None: 0} when a timer name was "
             "not passed into the class instance"
-
-    def test_elapsed_time_none_when_class_first_initialized(self):
-        t = ct.Timer()
-        assert t.elapsed_time is None
+        )
 
     def test_elapsed_time_returned_after_using_timer(self):
         with ct.Timer(name="my_timer") as t:
@@ -117,77 +82,73 @@ class TestTimerClass:
         assert t.elapsed_time > 0
         assert isinstance(t.elapsed_time, float)
 
-
-class TestTimerDec:
-    def test_deco_timer_with_brackets(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=PACKAGE_LOGGER)
-        decorated_timer_with_brackets()
-        log = caplog.records[-1].getMessage().lower()
-        assert RE_ELAPSED_TIME.match(log), \
-            f"Did not find text {str(RE_ELAPSED_TIME)} in log: {log}"
-
-    def test_deco_timer_without_brackets(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=PACKAGE_LOGGER)
-        decorated_timer_no_brackets()
-        log = caplog.records[-1].getMessage().lower()
-        assert RE_ELAPSED_TIME.match(log), \
-            f"Did not find text {str(RE_ELAPSED_TIME)} in log: {log}"
-
-    def test_deco_timer_name_passed(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=PACKAGE_LOGGER)
-        decorated_timer_name_passed()
-        log1 = caplog.records[-1].getMessage().lower()
-        log2 = caplog.records[1].getMessage().lower()
-        assert RE_ELAPSED_TIME.match(log1), \
-            f"Did not find text {str(RE_ELAPSED_TIME)} in log: {log1}"
-        assert TIMER_NAME_LOG in log2, \
-            f"Did not find text {TIMER_NAME_LOG} in log: {log2}"
-        assert re.search(RE_TIMER_NAME_LOG, log2), \
-            f"Did not find text {RE_TIMER_NAME_LOG} in log: {log2}"
+    def test_clear_all_timers(self):
+        with ct.Timer() as t:
+            timer_func()
+            t.clear()
+        assert t.timers == {t.DEFAULT_TIMER: 0}
 
 
-class TestTimeitDec:
+@ct.timeit(num_repeats=DEFAULT_TIMEIT_REPEATS, name="my_timer")
+def dec_timing():
+    return 3
 
-    def test_deco_timeit_info_level_logging(self, caplog):
+
+class TestTimerDecorators:
+    def test_deco_timer_with_kwargs(self):
+        @ct.timer(name="my_timer")
+        def timing():
+            return 3
+
+        assert timing() == 3
+
+    def test_timer_with_brackets_defaults(self):
+        @ct.timer()
+        def timing():
+            return 3
+
+        assert timing() == 3
+
+    def test_timer_no_brackets(self):
+        @ct.timer
+        def timing():
+            return 3
+
+        assert timing() == 3
+
+    def test_timeit_log_output(self, caplog):
         caplog.set_level(logging.INFO, logger=PACKAGE_LOGGER)
-        decorated_timeit_num_repeats()
+        dec_timing()
         assert len(caplog.records) == 1, "Contains more than one log output"
         assert caplog.records[0].levelname == "INFO", "Log level is not 'INFO'"
-        assert all([rec for rec in caplog.records if rec.levelno <= 20]), \
-            "Log record above 'INFO' level "
+        assert all(
+            [rec for rec in caplog.records if rec.levelno <= 20]
+        ), "Log record above 'INFO' level "
 
-    def test_deco_timeit_debug_level_logging(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=PACKAGE_LOGGER)
-        decorated_timeit_num_repeats()
-        assert len(caplog.records) >= DEFAULT_TIMEIT_REPEATS
-        assert caplog.records[0].levelname == "DEBUG"
-        assert caplog.records[-1].levelname == "INFO"
+    def test_timeit_with_kwargs(self):
+        assert dec_timing() == 3
 
-    def test_deco_timeit_empty_brackets(self, caplog):
-        caplog.set_level(logging.INFO, logger=PACKAGE_LOGGER)
-        decorated_timeit_with_brackets_no_arguments()
-        assert len(caplog.records) == 1, "Contains more than one log output"
-        assert caplog.records[0].levelname == "INFO", "Log level is not 'INFO'"
-        assert all([rec for rec in caplog.records if rec.levelno <= 20]), \
-            "Log record above 'INFO' level "
+    def test_timeit_with_brackets_defaults(self):
+        @ct.timeit()
+        def timing():
+            return 3
 
-    def test_deco_timeit_no_brackets(self, caplog):
-        caplog.set_level(logging.INFO, logger=PACKAGE_LOGGER)
-        decorated_timeit_no_brackets()
-        assert len(caplog.records) == 1, "Does not contain one " \
-                                         "single 'INFO' level log"
-        assert caplog.records[0].levelname == "INFO", "Log level is not 'INFO'"
-        assert all([rec for rec in caplog.records if rec.levelno <= 20]), \
-            "Log record above 'INFO' level "
+        assert timing() == 3
 
-    def test_deco_timeit_name_passed(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=PACKAGE_LOGGER)
-        func = decorated_timeit_num_repeats_and_name
-        func()
-        log1 = caplog.records[-1].getMessage().lower()
-        log2 = caplog.records[1].getMessage().lower()
-        assert TIMEIT_LOG + func.__name__ + ":" in log1
-        assert TIMER_NAME_LOG in log2, \
-            f"Did not find text {TIMER_NAME_LOG} in log: {log2}"
-        assert re.search(RE_TIMER_NAME_LOG, log2), \
-            f"Did not find text {RE_TIMER_NAME_LOG} in log: {log2}"
+    def test_timeit_no_brackets(self):
+        @ct.timeit
+        def timing():
+            return 3
+
+        assert timing() == 3
+
+    def test_recursive_timer(self):
+        @ct.recursive_timer
+        def fib(n):
+            if n <= 0:
+                return 0
+            elif n == 1:
+                return 1
+            return fib(n-2) + fib(n-1)
+        fib(25)
+

--- a/tests/test_code_timer.py
+++ b/tests/test_code_timer.py
@@ -82,12 +82,6 @@ class TestTimerClass:
         assert t.elapsed_time > 0
         assert isinstance(t.elapsed_time, float)
 
-    def test_clear_all_timers(self):
-        with ct.Timer() as t:
-            timer_func()
-            t.clear()
-        assert t.timers == {t.DEFAULT_TIMER: 0}
-
 
 @ct.timeit(num_repeats=DEFAULT_TIMEIT_REPEATS, name="my_timer")
 def dec_timing():


### PR DESCRIPTION
New features:
  * Recursive timer decorator
  * update timer name  
  * add elapsed to repr
  * change default timer name from `None` to "default"

Other updates:
  * removed most of the ridiculousness of unit-testing log line outputs
  * simplified unit-tests